### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, add-github-actions ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             compiler: clang
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
@@ -81,14 +81,14 @@ jobs:
 
     - name: Upload WAV file (Unix)
       if: matrix.os != 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ym2151_tone_${{ matrix.os }}_${{ matrix.compiler }}
         path: build/ym2151_tone.wav
 
     - name: Upload WAV file (Windows)
       if: matrix.os == 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ym2151_tone_${{ matrix.os }}_${{ matrix.compiler }}
         path: build/Release/ym2151_tone.wav

--- a/examples/simple_tone.cpp
+++ b/examples/simple_tone.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <cmath>
 #include <cstdint>
+#include <algorithm>  // std::clamp用
 
 // WAVファイルヘッダー構造体
 struct WAVHeader {


### PR DESCRIPTION
- **GitHub Actionsのアクションバージョンを更新: upload-artifact@v3→v4, checkout@v3→v4**
- **GitHub Actionsに手動実行トリガー(workflow_dispatch)を追加**
- **GitHub Actionsのトリガーブランチにadd-github-actionsを追加**
- **std::clamp関数を使用するために<algorithm>ヘッダーを追加**
