### PR TITLE
サンプリングレートがハードコードされている問題を修正

### DIFF
--- a/include/ym2151/ym2151.h
+++ b/include/ym2151/ym2151.h
@@ -79,6 +79,7 @@ public:
     void setFrequency(uint16_t frequency);
     void setAlgorithm(uint8_t algorithm);
     void setFeedback(uint8_t feedback);
+    void setSampleRate(uint32_t rate);
     void keyOn();
     void keyOff();
     void updateEnvelopes();
@@ -91,6 +92,7 @@ private:
     uint16_t frequency_;
     uint8_t algorithm_;
     uint8_t feedback_;
+    uint32_t sample_rate_;
     bool keyOnFlag_;
     float output_;
     float feedback_buffer_[2];


### PR DESCRIPTION
## 概要
Channel::getOutput メソッドでサンプリングレートが44100Hzにハードコードされていた問題を修正しました。

## 変更内容
- Channel クラスにサンプリングレートを設定するメソッド  を追加
- Channel::getOutput メソッドでハードコードされた44100Hzの代わりに設定されたサンプリングレートを使用
- Chip::setSampleRate メソッドで各チャンネルにもサンプリングレートを設定
- Chip::reset メソッドでも各チャンネルのサンプリングレートを設定

## 関連Issue
Closes #7